### PR TITLE
Fix Android build with NDK 26

### DIFF
--- a/src/render/opengles2/SDL_gles2funcs.h
+++ b/src/render/opengles2/SDL_gles2funcs.h
@@ -54,7 +54,7 @@ SDL_PROC(void, glPixelStorei, (GLenum, GLint))
 SDL_PROC(void, glReadPixels, (GLint, GLint, GLsizei, GLsizei, GLenum, GLenum, GLvoid*))
 SDL_PROC(void, glScissor, (GLint, GLint, GLsizei, GLsizei))
 SDL_PROC(void, glShaderBinary, (GLsizei, const GLuint *, GLenum, const void *, GLsizei))
-#if __NACL__ || __ANDROID__
+#if __NACL__
 SDL_PROC(void, glShaderSource, (GLuint, GLsizei, const GLchar **, const GLint *))
 #else
 SDL_PROC(void, glShaderSource, (GLuint, GLsizei, const GLchar* const*, const GLint *))


### PR DESCRIPTION
This change is required to build the Android port with NDK 26.